### PR TITLE
feat(CI): add workflow to sync upstream

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,22 @@
+name: Sync upstream
+
+on:
+  schedule:
+    - cron: '0 0 */3 * *' # midnight every 3 days
+jobs:
+  sync_upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: 'master'
+      - name: add upstream
+        run: |
+          git remote add upstream https://github.com/nuxt/nuxtjs.org.git
+      - name: pull upstream
+        run: |
+          git config pull.rebase false
+          git pull upstream master
+      - name: push
+        run: |
+          git push origin master


### PR DESCRIPTION
## Why

手動で upstream を取り込んで push しているのを自動化したい

## What

github actions のスケジュールを使って upstream を取り込むようにした

## Note

- とりあえず 3 日ごとに回るようにしています
- デフォルトブランチが dev に変更されましたが、このリポジトリは master のままで問題ないと思い変更していません
- このリポジトリをベースにPRを作ることはないはずなので、マージによる影響はないと思っています