### PR TITLE
fix(CI): error on pulling upstream

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -16,7 +16,7 @@ jobs:
       - name: pull upstream
         run: |
           git config pull.rebase false
-          git pull upstream master
+          git pull --allow-unrelated-histories upstream master
       - name: push
         run: |
           git push origin master


### PR DESCRIPTION
@aytdm 

I have fixed an error on pulling upstream.

https://github.com/vuejs-jp/ja.nuxtjs.org/runs/1403941072?check_suite_focus=true

> fatal: refusing to merge unrelated histories

ref: https://git-scm.com/docs/git-merge#Documentation/git-merge.txt---allow-unrelated-histories