### PR TITLE
fix(ci): set identity to fix fatal error on pulling upstream

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,6 +1,9 @@
 name: Sync upstream
 
 on:
+  push:
+    branches:
+      - fix-committer-identity-unknown
   schedule:
     - cron: '0 0 */3 * *' # midnight every 3 days
 jobs:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,9 +1,6 @@
 name: Sync upstream
 
 on:
-  push:
-    branches:
-      - fix-committer-identity-unknown
   schedule:
     - cron: '0 0 */3 * *' # midnight every 3 days
 jobs:

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -13,6 +13,10 @@ jobs:
       - name: add upstream
         run: |
           git remote add upstream https://github.com/nuxt/nuxtjs.org.git
+      - name: set identity # fix: fatal error on pulling upstream: empty ident name
+        run: |
+          git config user.email "inouetakuya5@gmail.com"
+          git config user.name "INOUE Takuya"
       - name: pull upstream
         run: |
           git config pull.rebase false


### PR DESCRIPTION
I have fixed the following error on pulling upstream.

https://github.com/vuejs-jp/ja.nuxtjs.org/runs/1436946073?check_suite_focus=true

```
Run git config pull.rebase false
  git config pull.rebase false
  git pull --allow-unrelated-histories upstream master
  shell: /bin/bash -e {0}
From https://github.com/nuxt/nuxtjs.org
 * branch            master     -> FETCH_HEAD
 * [new branch]      master     -> upstream/master
Committer identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az67-225.mqnyvfsspquelmca3dr1xxs2xg.gx.internal.cloudapp.net>) not allowed
Error: Process completed with exit code 128.
```
